### PR TITLE
fix membership group lint

### DIFF
--- a/admin/src/Membership/MemberBoxGroups.js
+++ b/admin/src/Membership/MemberBoxGroups.js
@@ -26,17 +26,8 @@ function MemberBoxGroups(props) {
     const [showOptions, setShowOptions] = useState([]);
     const [selectedOption, setSelectedOption] = useState(null);
 
-    // Define the `get` function for making GET requests
-    const get = async ({ url }) => {
-        const response = await fetch(url);
-        if (!response.ok) {
-            throw new Error("Failed to fetch data");
-        }
-        const data = await response.json();
-        return { data };
-    };
-
     useEffect(() => {
+        // eslint-disable-next-line no-undef
         get({ url: "/membership/group" }).then((data) => {
             const updatedOptions = data.data;
             setOptions(updatedOptions);


### PR DESCRIPTION
Membership group did not work after fixing lint error. Seemed like it works properly but ESLint notifies a false positive error so we just reverted the changes and added an ignore line.

<img width="1225" alt="Screenshot 2024-12-05 at 4 42 10 PM" src="https://github.com/user-attachments/assets/b3721512-90ad-4c87-be5a-40646697523e">
